### PR TITLE
Fixed an issue where older python versions did not work

### DIFF
--- a/poetry_plugin_appimage/templates/build_appimage.sh.mako
+++ b/poetry_plugin_appimage/templates/build_appimage.sh.mako
@@ -52,8 +52,7 @@ cleanup() {
 export ARCH="x86_64"
 
 # Env for linuxdeploy-plugin-conda
-export CONDA_PYTHON_VERSION="${python}"
-export MINICONDA_VERSION="${miniconda}"
+export MINICONDA_DIST="${miniconda_dist_name}"
 export PIP_REQUIREMENTS="-r requirements_for_appimage.txt"  # install argument is added by linuxdeploy-plugin-conda.sh
 export PIP_WORKDIR="$REPO_ROOT"
 export CONDA_SKIP_CLEANUP="strip;.a;cmake;doc;man;"

--- a/readme.md
+++ b/readme.md
@@ -25,6 +25,11 @@ Options:
 ~~~
 
 Define the following section in your project's `pyproject.toml` with a valid [miniconda version](https://repo.anaconda.com/miniconda/) and python version. 
+If python and miniconda are defined, the corresponding distribution
+of Miniconda3-py\<**python**\>-\<**miniconda**\> will be used.
+If either is not defined, Miniconda3-latest will be used.
+
+
 Categories must be seperated by a semi-colon.
 
 ~~~

--- a/tests/prep_for_e2e_test.sh
+++ b/tests/prep_for_e2e_test.sh
@@ -13,7 +13,7 @@ fi
 REPO_ROOT="$(dirname "$(dirname "$(readlink -fm "$0")")")"
 
 pushd "$REPO_ROOT/example_project/" || exit
-rm dist/*.AppImage
+rm -f dist/*.AppImage
 poetry install
 poetry run poetry build-appimage -b 42
 poetry env remove "$(poetry env list | awk '{print $1;}')"

--- a/tests/test_e2e.py
+++ b/tests/test_e2e.py
@@ -40,7 +40,8 @@ def test_e2e_basic(appimage: str):
 def test_e2e_versions(appimage: str):
     with does_not_raise():
         op = subprocess.check_output([appimage, "main"])
-        result = json.loads(op.decode("utf8"))
+        result_string = "".join(op.decode("utf8").replace("\n","").partition('{')[1:])
+        result = json.loads(result_string)
 
     # No exception above signifies no import errors and an intact appimage
 

--- a/tests/test_mako_template.py
+++ b/tests/test_mako_template.py
@@ -11,6 +11,7 @@ def metadata():
         app_name="appname with spaces",
         version="4.2.0",
         miniconda="0.2.4",
+        miniconda_dist_name="Miniconda3-py37_0.2.4-Linux-x86_64.sh",
         python="3.7",
         categories="ConsoleOnly;",
         entry_points=[],


### PR DESCRIPTION
miniconda version was ignored. This meant that if you want an older python version you needed to download the newest miniconda and downgrade using "conda install python=<lower version>" which failed when I tried going from 3.11 to 3.7.

Also I fixed string parsing in one of the tests